### PR TITLE
Update 'bin' in package.json to enable execution direct from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "server-wp-mcp",
 	"version": "1.0.0",
 	"main": "dist/index.js",
+	"bin": {
+		"server-wp-mcp": "dist/index.js"
+	},
 	"type": "module",
 	"scripts": {
 		"start": "node dist/index.js"


### PR DESCRIPTION
Defining `bin` in package.json allows for execution direct from github ie

```
WP_SITES_PATH=./wp-sites.json npx -y github:matthewhand/server-wp-mcp
WordPress MCP server started with 1 site(s) configured
```

versus without

```
WP_SITES_PATH=./wp-sites.json npx -y github:emzimmer/server-wp-mcp
npm error could not determine executable to run
```